### PR TITLE
Add crytic-compile support (raw Solidity + Truffle + Embark integration)

### DIFF
--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -7,6 +7,7 @@ from pkg_resources import require
 from pyevmasm import disassemble_all
 
 from crytic_compile import cryticparser, CryticCompile, InvalidCompilation, is_supported
+from . import known_hashes
 
 from .cfg import CFG
 
@@ -71,6 +72,8 @@ def main():
             for contract in cryticCompile.contracts_names:
                 bytecode_init = cryticCompile.bytecode_init(contract)
                 if bytecode_init:
+                    for signature, hash in cryticCompile.hashes(contract).items():
+                        known_hashes[hash] = signature
                     logger.info(f'Analyze {contract}')
                     _run(bytecode_init, f'{filename}-{contract}-init', args)
                     _run(cryticCompile.bytecode_runtime(contract),  f'{filename}-{contract}-runtime', args)

--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -6,6 +6,8 @@ import os
 from pkg_resources import require
 from pyevmasm import disassemble_all
 
+from crytic_compile import cryticparser, CryticCompile
+
 from .cfg import CFG
 
 logging.basicConfig()
@@ -31,13 +33,14 @@ def parse_args():
                         help='Export the functions to .dot files in the directory',
                         action='store',
                         dest='dot_directory',
-                        default='')
+                        default='crytic-export/evm')
 
     parser.add_argument('--version',
                         help='displays the current version',
                         version=require('evm-cfg-builder')[0].version,
                         action='version')
 
+    cryticparser.init(parser)
 
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
@@ -45,22 +48,38 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-def main():
-
-    l = logging.getLogger('evm-cfg-builder')
-    l.setLevel(logging.INFO)
-    args = parse_args()
-
-    with open(args.filename, 'rb') as f:
-        bytecode = f.read()
-
+def _run(bytecode, filename, args):
     cfg = CFG(bytecode)
 
     for function in cfg.functions:
         logger.info(function)
 
     if args.dot_directory:
-        output_to_dot(args.dot_directory, args.filename, cfg)
+        output_to_dot(args.dot_directory, filename, cfg)
+
+def main():
+
+    l = logging.getLogger('evm-cfg-builder')
+    l.setLevel(logging.INFO)
+    args = parse_args()
+
+    if args.filename.endswith('.sol') or os.path.isdir(args.filename):
+        filename = args.filename
+        del args.filename
+        cryticCompile = CryticCompile(filename, **vars(args))
+        for contract in cryticCompile.contracts_name:
+            logger.info(f'Analyze {contract}')
+            _run(cryticCompile.init_bytecode(contract), f'{filename}-{contract}-init', args)
+            _run(cryticCompile.runtime_bytecode(contract),  f'{filename}-{contract}-runtime', args)
+
+    else:
+        with open(args.filename, 'rb') as f:
+            bytecode = f.read()
+        logger.info(f'Analyze {args.filename}')
+        _run(bytecode, args.filename, args)
+
+
+
 
 
 if __name__ == '__main__':

--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -69,9 +69,11 @@ def main():
         try:
             cryticCompile = CryticCompile(filename, **vars(args))
             for contract in cryticCompile.contracts_names:
-                logger.info(f'Analyze {contract}')
-                _run(cryticCompile.bytecode_init(contract), f'{filename}-{contract}-init', args)
-                _run(cryticCompile.bytecode_runtime(contract),  f'{filename}-{contract}-runtime', args)
+                bytecode_init = cryticCompile.bytecode_init(contract)
+                if bytecode_init:
+                    logger.info(f'Analyze {contract}')
+                    _run(bytecode_init, f'{filename}-{contract}-init', args)
+                    _run(cryticCompile.bytecode_runtime(contract),  f'{filename}-{contract}-runtime', args)
         except InvalidCompilation as e:
             logger.error(e)
 

--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -70,8 +70,8 @@ def main():
             cryticCompile = CryticCompile(filename, **vars(args))
             for contract in cryticCompile.contracts_names:
                 logger.info(f'Analyze {contract}')
-                _run(cryticCompile.init_bytecode(contract), f'{filename}-{contract}-init', args)
-                _run(cryticCompile.runtime_bytecode(contract),  f'{filename}-{contract}-runtime', args)
+                _run(cryticCompile.bytecode_init(contract), f'{filename}-{contract}-init', args)
+                _run(cryticCompile.bytecode_runtime(contract),  f'{filename}-{contract}-runtime', args)
         except InvalidCompilation as e:
             logger.error(e)
 

--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -68,7 +68,7 @@ def main():
         del args.filename
         try:
             cryticCompile = CryticCompile(filename, **vars(args))
-            for contract in cryticCompile.contracts_name:
+            for contract in cryticCompile.contracts_names:
                 logger.info(f'Analyze {contract}')
                 _run(cryticCompile.init_bytecode(contract), f'{filename}-{contract}-init', args)
                 _run(cryticCompile.runtime_bytecode(contract),  f'{filename}-{contract}-runtime', args)

--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -6,7 +6,7 @@ import os
 from pkg_resources import require
 from pyevmasm import disassemble_all
 
-from crytic_compile import cryticparser, CryticCompile
+from crytic_compile import cryticparser, CryticCompile, InvalidCompilation
 
 from .cfg import CFG
 
@@ -66,11 +66,14 @@ def main():
     if args.filename.endswith('.sol') or os.path.isdir(args.filename):
         filename = args.filename
         del args.filename
-        cryticCompile = CryticCompile(filename, **vars(args))
-        for contract in cryticCompile.contracts_name:
-            logger.info(f'Analyze {contract}')
-            _run(cryticCompile.init_bytecode(contract), f'{filename}-{contract}-init', args)
-            _run(cryticCompile.runtime_bytecode(contract),  f'{filename}-{contract}-runtime', args)
+        try:
+            cryticCompile = CryticCompile(filename, **vars(args))
+            for contract in cryticCompile.contracts_name:
+                logger.info(f'Analyze {contract}')
+                _run(cryticCompile.init_bytecode(contract), f'{filename}-{contract}-init', args)
+                _run(cryticCompile.runtime_bytecode(contract),  f'{filename}-{contract}-runtime', args)
+        except InvalidCompilation as e:
+            logger.error(e)
 
     else:
         with open(args.filename, 'rb') as f:

--- a/evm_cfg_builder/__main__.py
+++ b/evm_cfg_builder/__main__.py
@@ -6,7 +6,7 @@ import os
 from pkg_resources import require
 from pyevmasm import disassemble_all
 
-from crytic_compile import cryticparser, CryticCompile, InvalidCompilation
+from crytic_compile import cryticparser, CryticCompile, InvalidCompilation, is_supported
 
 from .cfg import CFG
 
@@ -63,7 +63,7 @@ def main():
     l.setLevel(logging.INFO)
     args = parse_args()
 
-    if args.filename.endswith('.sol') or os.path.isdir(args.filename):
+    if is_supported(args.filename):
         filename = args.filename
         del args.filename
         try:

--- a/evm_cfg_builder/cfg/__init__.py
+++ b/evm_cfg_builder/cfg/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from .basic_block import BasicBlock
 from .function import Function
 
@@ -9,6 +10,8 @@ from ..value_set_analysis import StackValueAnalysis
 import re
 from pyevmasm import disassemble_all
 
+logger = logging.getLogger("evm-cfg-builder")
+
 BASIC_BLOCK_END = [
     'STOP',
     'SELFDESTRUCT',
@@ -19,6 +22,45 @@ BASIC_BLOCK_END = [
     'JUMP',
     'JUMPI'
 ]
+
+def convert_bytecode(bytecode):
+    '''
+        Convert the bytecode to bytes
+        Remove trailing \n
+        Remove '0x'
+        Replace library call to 'AAA.AAA'
+        Args:
+            bytecode (str|bytes)
+        Return:
+            (bytes)
+    '''
+    if bytecode is not None:
+        if isinstance(bytecode, str):
+            for library_found in re.findall(r'__.{36}__', bytecode):
+                logger.info('Replace library %s by %s', library_found, 'A'*40)
+            bytecode = re.sub(
+                r'__.{36}__',
+                'A'*40,
+                bytecode
+            )
+
+            bytecode = bytecode.replace('\n', '')
+            if bytecode.startswith('0x'):
+                bytecode = bytes.fromhex(bytecode[2:])
+            else:
+                bytecode = bytes.fromhex(bytecode)
+        else:
+            for library_found in re.findall(b'__.{36}__', bytecode):
+                logger.info('Replace library %s by %s', library_found, 'A'*40)
+            bytecode = re.sub(
+                b'__.{36}__',
+                b'A'*40,
+                bytecode
+            )
+            if bytecode.startswith(b'0x'):
+                bytecode = bytes.fromhex(bytecode[2:].decode().replace('\n', ''))
+
+    return bytecode
 
 class CFG(object):
     """Implements the control flow graph (CFG) of an EVM bytecode.
@@ -44,18 +86,7 @@ class CFG(object):
 
         assert(isinstance(bytecode, (type(None), str, bytes)))
 
-        if bytecode is not None:
-            if isinstance(bytecode, str):
-                bytecode = bytecode.replace('\n', '')
-                if bytecode.startswith('0x'):
-                    bytecode = bytes.fromhex(bytecode[2:])
-                else:
-                    bytecode = bytecode.encode('charmap')
-            else:
-                if bytecode.startswith(b'0x'):
-                    bytecode = bytes.fromhex(bytecode[2:].decode().replace('\n', ''))
-
-        self._bytecode = bytecode
+        self._bytecode = convert_bytecode(bytecode)
 
         if remove_metadata:
             self.remove_metadata()
@@ -76,12 +107,7 @@ class CFG(object):
     def bytecode(self, bytecode):
         assert(isinstance(bytecode, (type(None), str, bytes)))
 
-        if bytecode is not None:
-            if isinstance(bytecode, str):
-                if bytecode.startswith('0x'):
-                    bytecode = bytes.fromhex(bytecode[2:])
-                else:
-                    bytecode = bytecode.encode('charmap')
+        bytecode = convert_bytecode(bytecode)
 
         self.clear()
         self._bytecode = bytecode
@@ -302,7 +328,7 @@ class CFG(object):
 
                 f.write('{}[label="{}"]\n'.format(basic_block.start.pc, instructions))
 
-                for son in basic_block.all_incoming_basic_blocks:
+                for son in basic_block.all_outgoing_basic_blocks:
                     f.write('{} -> {}\n'.format(basic_block.start.pc, son.start.pc))
 
             f.write('\n}')

--- a/evm_cfg_builder/cfg/function.py
+++ b/evm_cfg_builder/cfg/function.py
@@ -155,13 +155,13 @@ class Function(object):
 
                 f.write('{}[label="{}"]\n'.format(basic_block.start.pc, instructions))
 
-                if self.key in basic_block.incoming_basic_blocks_as_dict:
-                    for son in basic_block.incoming_basic_blocks_as_dict[self.key]:
-                        f.write('{} -> {}\n'.format(basic_block.start.pc, son.start.pc))
+                for son in basic_block.outgoing_basic_blocks(self.key):
+                    f.write('{} -> {}\n'.format(basic_block.start.pc, son.start.pc))
 
-                elif basic_block.ends_with_jump_or_jumpi():
-                    logger.error('Missing branches {}:{}'.format(self.name,
-                                                                 hex(basic_block.end.pc)))
+                if not basic_block.outgoing_basic_blocks(self.key):
+                    if basic_block.ends_with_jump_or_jumpi():
+                        logger.error('Missing branches {}:{}'.format(self.name,
+                                                                     hex(basic_block.end.pc)))
 
             f.write('\n}')
 
@@ -178,13 +178,13 @@ class Function(object):
 
                 f.write('{}[label="{}"]\n'.format(basic_block.start.pc, instructions))
 
-                if self.key in basic_block.incoming_basic_blocks_as_dict:
-                    for son in basic_block.incoming_basic_blocks_as_dict[self.key]:
-                        f.write('{} -> {}\n'.format(basic_block.start.pc, son.start.pc))
+                for son in basic_block.outgoing_basic_blocks(self.key):
+                    f.write('{} -> {}\n'.format(basic_block.start.pc, son.start.pc))
 
-                elif basic_block.ends_with_jump_or_jumpi():
-                    logger.error('Missing branches {}:{}'.format(self.name,
-                                                                 hex(basic_block.end.pc)))
+                if not basic_block.outgoing_basic_blocks(self.key):
+                    if basic_block.ends_with_jump_or_jumpi():
+                        logger.error('Missing branches {}:{}'.format(self.name,
+                                                                     hex(basic_block.end.pc)))
             for function in self._cfg.functions:
                 if function != self:
                     f.write('{}[label="Call {}"]\n'.format(function.start_addr, function.name))

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -13,3 +13,8 @@ function install_solc {
 }
 
 install_solc
+
+git clone https://github.com/crytic/crytic-compile
+cd crytic-compile
+pip install .
+

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version='0.2.0',
     packages=find_packages(),
     python_requires='>=3.6',
-    install_requires=['pyevmasm>=0.1.1'],
+    install_requires=['pyevmasm>=0.1.1', 'crytic-compile>=0.1.1'],
     license='AGPL-3.0',
     long_description=open('README.md').read(),
     entry_points={


### PR DESCRIPTION
This PR uses [crytic-compile](https://github.com/crytic/crytic-compile) to run evm-cfg-builder on a solidity file
```
evm-cfg-builder file.sol
```
Or a Truffle/Embark/Etherlime directory:
```
evm-cfg-builder . 
```
Or from the verified contract on etherscan
```
evm-cfg-builder 0x...
```

All the .dot files are generated in `crytic-export/evm` (both init and runtime bytecode)

Additionally, the hashes from the contracts are also added to the known hashes dict, so compiling from source code always lead to know all the function ids.