### PR TITLE
Adds support for Constantinople opcodes

### DIFF
--- a/evm_cfg_builder/cfg/function.py
+++ b/evm_cfg_builder/cfg/function.py
@@ -79,6 +79,7 @@ class Function(object):
 
     def check_view(self):
         changing_state_ops = ['CREATE',
+                              'CREATE2',
                               'CALL',
                               'CALLCODE',
                               'DELEGATECALL',
@@ -93,6 +94,7 @@ class Function(object):
 
     def check_pure(self):
         state_ops = ['CREATE',
+                     'CREATE2',
                      'CALL',
                      'CALLCODE',
                      'DELEGATECALL',
@@ -109,6 +111,7 @@ class Function(object):
                      'CODESIZE',
                      'CODECOPY',
                      'EXTCODESIZE',
+                     'EXTCODEHASH',
                      'EXTCODECOPY',
                      'RETURNDATASIZE',
                      'RETURNDATACOPY',
@@ -119,7 +122,6 @@ class Function(object):
                      'DIFFICULTY',
                      'GASLIMIT',
                      'LOG0', 'LOG1', 'LOG2', 'LOG3', 'LOG4',
-                     'CREATE',
                      'CALL',
                      'CALLCODE',
                      'DELEGATECALL',


### PR DESCRIPTION
- Adds Constantinople opcodes `EXTCODEHASH` and `CREATE2` for pure/view function attribute checks
- Removes a duplicate `CREATE` in `check_pure()`
- *Not tested* because no unit test framework (To-do)