### PR TITLE
Add pip-audit action workflow

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,27 @@
+name: pip-audit
+
+on:
+  push:
+    branches: [ dev, master ]
+  pull_request:
+    branches: [ dev, master ]
+  schedule: [ cron: "0 7 * * 2" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install pip-audit
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pip-audit
+    - name: Run pip-audit
+      run: |
+        echo "-e ." > audit.txt
+        pip-audit --strict --desc -r audit.txt


### PR DESCRIPTION
This adds a new GitHub Actions workflow. This workflow runs pip-audit
on the repository on each new commit and pull request to the `dev` and
`master` branches, as well as every Tuesday morning. If any known vulnerable
dependency is found, this workflow will fail.